### PR TITLE
Remove /topic/topic links

### DIFF
--- a/content/data-life-cycle/collect.md
+++ b/content/data-life-cycle/collect.md
@@ -10,7 +10,7 @@ toc: True
 
 ## Collecting
 <!-- About/intro to the phase -->
-<!-- refer to metadata standard page /topic/topic/metadata.md -->
+<!-- refer to metadata standard page /topic/metadata.md -->
 
 Click on the data type buttons below to see which facilities who offer data generation services:
 <p>

--- a/content/data-life-cycle/plan.md
+++ b/content/data-life-cycle/plan.md
@@ -15,7 +15,7 @@ High quality science is often only possible if the resource facilities you inten
 
 It is wise to write a data management plan (DMP), using either a tool provided by your university or [DS wizard](http://dsw.scilifelab.se/). The main benefits of writing a DMP are to collect how the data is managed and identify possible gaps in the current data management practices. Think of the DMP as a checklist to go through when planning for a new project.
 
-Also, some resources have specific application periods and thus needs to be contacted well in advance. If your project includes sensitive (human) data, note that there are ethical and legal issues that you have to consider, such as apply for an ethics approval, establish necessary agreements and report the data processing to your [Data Protection Officer](/topic/topic/data-protection-officer.md). See the page on [Sensitive data](/topic/topic/sensitive-data.md) for more information.
+Also, some resources have specific application periods and thus needs to be contacted well in advance. If your project includes sensitive (human) data, note that there are ethical and legal issues that you have to consider, such as apply for an ethics approval, establish necessary agreements and report the data processing to your [Data Protection Officer](/topic/data-protection-officer.md). See the page on [Sensitive data](/topic/sensitive-data.md) for more information.
 
 
 ### Resources & Training

--- a/content/data-life-cycle/preserve.md
+++ b/content/data-life-cycle/preserve.md
@@ -11,7 +11,7 @@ toc: True
 ## Preserve
 <!-- About/intro to the phase, including link to RDMkit -->
 
-After the project is finished, the data needs to be stored in a backed-up fashion at least for 10 years, and for as long as the data is of scientific value. After this time, some of the data should be archived and some can be disposed. It is best to contact your [university](/topic/topic/research-data-office.md) for information about the procedures for this.
+After the project is finished, the data needs to be stored in a backed-up fashion at least for 10 years, and for as long as the data is of scientific value. After this time, some of the data should be archived and some can be disposed. It is best to contact your [university](/topic/research-data-office.md) for information about the procedures for this.
 
 [SNIC](https://www.snic.se/allocations/storage/) offers storage for small and medium-sized datasets. In the future also large-sized storage will be offered.
 

--- a/content/topic/human-data-PI.md
+++ b/content/topic/human-data-PI.md
@@ -5,8 +5,8 @@
 ## Human data - What you should as a PI
 * Be aware of that if your project contains human derived biomedical data, it is most probably ‘[sensitive data](#what-is-sensitive-personal-data)’.
 * Be aware of that [you](#who-is-responsible-for-the-data) (as an employee of your institute) must ensure that the GDPR (and other laws) are followed.
-* Be able to demonstrate that you follow the GDPR (see [human data legal reference page for more info](/topic/topic/human-data-legal.md)). E.g. define the purpose for processing the data, decide on the legal basis, protect the data, etc
-* In case you work at a different institute than Uppsala University, ensure that there is a data processing agreement between your institute and Uppsala University. This is the legal instruction from you as the representative of the Controller to NBIS in the role of Processor. [General processing agreements](/topic/topic/general-processing-agreements.md) have been established with some Swedish universities, and more are on their way.
+* Be able to demonstrate that you follow the GDPR (see [human data legal reference page for more info](/topic/human-data-legal.md)). E.g. define the purpose for processing the data, decide on the legal basis, protect the data, etc
+* In case you work at a different institute than Uppsala University, ensure that there is a data processing agreement between your institute and Uppsala University. This is the legal instruction from you as the representative of the Controller to NBIS in the role of Processor. [General processing agreements](/topic/general-processing-agreements.md) have been established with some Swedish universities, and more are on their way.
 * Inform the NBIS bioinformaticians about the conditions for what can and cannot be done to the data according to [ethical permit(s) and informed consent text(s)](#ethical-permits-and-informed-consents).
 * Define the procedures for how the personal data should be handled in the project, and communicate these to all involved, including NBIS bioinformaticians.
 * [Make the data available to the NBIS bioinformatician](#how-do-nbis-bioinformaticians-access-and-analyse-sensitive-personal-data) in a compute environment with a suitable level of security, which is typically the Bianca system at UPPMAX. If necessary, decide and approve alternative compute solutions outside of Bianca for NBIS bioinformaticians to use. Note that working with sensitive data outside of Bianca is highly discouraged, the motivation for which should be documented! In case you work at a different institute than Uppsala University, you need a data processing agreement between your institute and UPPMAX/Uppsala University for using the Bianca system - see [instructions](https://www.uppmax.uu.se/support/faq/general-miscellaneous-faq/sensitive+data+questions/) at UPPMAX.
@@ -14,9 +14,9 @@
 * It is advisable that you have a strategy regarding if and how so called ‘[secondary findings](https://pubmed.ncbi.nlm.nih.gov/25150271/)’ should be acted on vis-a-vis the research subjects.
 * Deposit the data in a [controlled access repository](#how-do-i-publish-sensitive-personal-data), during (preferably) or after the project.
 
-Also consider going through this [Ethical, Legal and Social implications (ELSI) checklist](/topic/topic/sensitive-data.md) for your project.
+Also consider going through this [Ethical, Legal and Social implications (ELSI) checklist](/topic/sensitive-data.md) for your project.
 
-You are welcome to contact the NBIS data manager for further consultation (<data@nbis.se>). Also, do consult with the [Data Protection Officer](/topic/topic/data-protection-officer.md) (“Dataskyddsombud”) of your employer.
+You are welcome to contact the NBIS data manager for further consultation (<data@nbis.se>). Also, do consult with the [Data Protection Officer](/topic/data-protection-officer.md) (“Dataskyddsombud”) of your employer.
 
 ## More information
 ### What is sensitive personal data

--- a/content/topic/human-data-bioinformatician.md
+++ b/content/topic/human-data-bioinformatician.md
@@ -4,7 +4,7 @@
 * The PI shall instruct the NBIS bioinformatician how the data shall be handled. This includes the procedures that the PI has established for handling the personal data in a secure way, and the instructions outlined in any processing agreements.
 * The PI shall inform the NBIS bioinformatician about any limitations of use for the data that might be specified in ethical approvals and/or informed consents.
 * The NBIS bioinformatician **must not** handle the data in any way that goes outside of the instructions and any limitations of use.
-* In the case of a [data breach](/topic/topic/human-data-legal-ref.md#data-breach), accidental or otherwise, this must be **immediatly reported to the PI**.
+* In the case of a [data breach](/topic/human-data-legal-ref.md#data-breach), accidental or otherwise, this must be **immediatly reported to the PI**.
 * Findings outside the scope of the study (secondary findings) should never be looked for by the NBIS bioinformatician, and should always be reported to the PI if accidentally found.
 * The default mode of operation is that large-scale sensitive personal data should be analysed at the national computer cluster specifically dedicated to sensitive personal data, [Bianca](http://www.uppmax.uu.se/support/user-guides/bianca-user-guide/).
 * If an NBIS bioinformatician plans to analyse sensitive personal data elsewhere, they must get the approval from the PI to process the personal data outside Bianca. Please also consult with the NBIS data manager (<data@nbis.se>). 
@@ -12,7 +12,7 @@
   *Note that working with sensitive data outside of Bianca is highly discouraged, and needs a documented motivation!*
 
 ## General processing agreements
-NBIS is working on establishing general processing agreements with other Swedish universities. A [list of established agreements](/topic/topic/general-processing-agreements.md) is available.
+NBIS is working on establishing general processing agreements with other Swedish universities. A [list of established agreements](/topic/general-processing-agreements.md) is available.
 
 The instructional content of these agreements is listed here (*translated from the Swedish text in the agreements*).
 


### PR DESCRIPTION
Correcting a previous trigger-happy search and replace action, where links to
 folder /topic got duplicated.