### PR TITLE
Changed the display of topics

### DIFF
--- a/content/topic/_index.md
+++ b/content/topic/_index.md
@@ -15,7 +15,7 @@ menu:
 
 Click on either of the links below to get an overview of individual research data management topics.
 
-{{< list-topics >}}
+{{<display-topics >}}
 
 <!--### Human data pages
  I imagine that we might want to gather some of these pages into a single one, with subheadings instead?

--- a/content/topic/data-protection-officer.md
+++ b/content/topic/data-protection-officer.md
@@ -3,7 +3,7 @@ title: Data Protection Officer
 menu:
     bottom_about:
         name: Data Protection Officer
-        identifier: dpo
+        identifier: data-protection-officer
         weight: 10
 toc: True
 ---
@@ -21,7 +21,7 @@ The role of the data protection officer is to check that the General Data Protec
 | KTH Royal Institute of Technology | dataskyddsombud@kth.se | [Processing of personal data at KTH](https://intra.kth.se/en/anstallning/anstallningsvillkor/att-vara-statligt-an/behandling-av-person) |
 | Linköping University | dataskyddsombud@liu.se |  |
 | Lund University | dataskyddsombud@lu.se | [Registration of personal data processing](https://www.staff.lu.se/support-and-tools/legal-and-records-management/personal-data-and-data-protection/area-specific-information/research) |
-| Stockholm University | dso@su.se | [GDPR at SU](https://www.su.se/english/staff/organisation-governance/legal-information) | 
+| Stockholm University | dso@su.se | [GDPR at SU](https://www.su.se/english/staff/organisation-governance/legal-information) |
 | Swedish University of Agricultural Sciences | dataskydd@slu.se | [Data protection and personal data](https://internt.slu.se/en/support-services/administrative-support/legal-affairs-data-protection-info-management/data-protection/) |
 | Umeå University | pulo@umu.se | [Personuppgifter](https://www.aurora.umu.se/stod-och-service/rad-och-riktlinjer/juridik-och-personuppgifter/personuppgifter/) |
 | University of Gothenburg | dataskydd@gu.se | [Routines for processing personal data](https://medarbetarportalen.gu.se/diarieforing-arkivering-och-personuppgiftsbehandling/rutiner-for-behandling-av-personuppgifter/)|

--- a/content/topic/fair-principles.md
+++ b/content/topic/fair-principles.md
@@ -3,7 +3,7 @@ title: FAIR principles
 menu:
     bottom_about:
         name: FAIR principles
-        identifier: FAIR
+        identifier: fair-principles
         weight: 10
 toc: True
 ---
@@ -12,7 +12,7 @@ toc: True
 
 [FAIR](https://www.force11.org/group/fairgroup/fairprinciples) stands for Findable, Accessible, Interoperable and Reusable. In [Wilkinson, et al 2016](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4792175/pdf/sdata201618.pdf) a set of principles were defined for each of these properties. Below, each of the principles are explained further (click on the buttons for detailed information), as adapted from [FAIR principles translation](http://www.snf.ch/SiteCollectionDocuments/FAIR_principles_translation_SNSF_logo.pdf).
 
-## Findable 
+## Findable
 Data and metadata should be easy to find by both humans and computer systems. Basic machine readable descriptive metadata allows the discovery of interesting datasets and services.
 <p>
   <a class="btn btn-primary" data-bs-toggle="collapse" href="#collapseFind1" role="button" aria-expanded="false" aria-controls="collapseFind1">

--- a/content/topic/general-processing-agreements.md
+++ b/content/topic/general-processing-agreements.md
@@ -1,3 +1,12 @@
+---
+title: General processing agreements
+menu:
+    bottom_about:
+        name: General processing agreements
+        identifier: data-transfer
+        weight: 10
+toc: True
+---
 # General processing agreements for bioinformatics support and data storage
 When researchers from universities other than Uppsala University use the services of NBIS involving personal data, NBIS/Uppsala University will act as Processor for the Controller (which is the university where the researcher is employed). In such cases, an agreement must be established between the Controller and the Processor according to [Article 28 (3)](https://gdpr-info.eu/art-28-gdpr/) of the GDPR.
 

--- a/content/topic/human-data-PI.md
+++ b/content/topic/human-data-PI.md
@@ -1,3 +1,14 @@
+---
+title: Human data PI
+category: Human data
+menu:
+    bottom_about:
+        name: Human data PI
+        identifier: human-data-pi
+        weight: 10
+toc: True
+---
+
 # PIs - working with human data
 
 ***Disclaimer!**  The PI, as well as everyone with access to sensitive personal data, is responsible for following current laws and regulations, and NBIS will not assume legal responsibility for advice provided in these guidelines.*

--- a/content/topic/human-data-bioinformatician.md
+++ b/content/topic/human-data-bioinformatician.md
@@ -1,3 +1,13 @@
+---
+title: Human data bioinformatician
+category: Human data
+menu:
+    bottom_about:
+        name: Human data bioinformatician
+        identifier: human-data-bioinformatician
+        weight: 10
+toc: True
+---
 # Working practices for NBIS bioinformaticians in support projects with human data
 * It is the PI’s responsibility (as the representative of his/her employer) to ensure that the personal data is handled according to existing laws and regulations.
 * The NBIS bioinformatician (as the representative of his/her employer) that processes the data on behalf of the PI, also has a legal responsibility to handle the data according to existing laws and regulations.
@@ -7,7 +17,7 @@
 * In the case of a [data breach](/topic/human-data-legal-ref.md#data-breach), accidental or otherwise, this must be **immediatly reported to the PI**.
 * Findings outside the scope of the study (secondary findings) should never be looked for by the NBIS bioinformatician, and should always be reported to the PI if accidentally found.
 * The default mode of operation is that large-scale sensitive personal data should be analysed at the national computer cluster specifically dedicated to sensitive personal data, [Bianca](http://www.uppmax.uu.se/support/user-guides/bianca-user-guide/).
-* If an NBIS bioinformatician plans to analyse sensitive personal data elsewhere, they must get the approval from the PI to process the personal data outside Bianca. Please also consult with the NBIS data manager (<data@nbis.se>). 
+* If an NBIS bioinformatician plans to analyse sensitive personal data elsewhere, they must get the approval from the PI to process the personal data outside Bianca. Please also consult with the NBIS data manager (<data@nbis.se>).
 
   *Note that working with sensitive data outside of Bianca is highly discouraged, and needs a documented motivation!*
 

--- a/content/topic/human-data-legal-ref.md
+++ b/content/topic/human-data-legal-ref.md
@@ -1,3 +1,14 @@
+---
+title: Human data legal reference
+category: Human data
+menu:
+    bottom_about:
+        name: Human data legal reference
+        identifier: human-data-legal-reference
+        weight: 10
+toc: True
+---
+
 # Legal reference - Personal data
 >This section is an attempt to describe the reasoning behind the NBIS guidelines regarding working with human data in more detail by referring to relevant sections of the **General Data Protection Regulation (GDPR)**, the EU-wide legislation that stipulates how personal data should be handled.
 >

--- a/content/topic/policies.md
+++ b/content/topic/policies.md
@@ -3,7 +3,7 @@ title: University guidelines and policies
 menu:
     bottom_about:
         name: University guidelines and policies
-        identifier: guidelines-policies
+        identifier: university-guidelines-policies
         weight: 10
 toc: True
 ---
@@ -16,7 +16,7 @@ Needs to be checked for updates on other uni:s -->
 
 * Stockholm University - <https://www.su.se/medarbetare/organisation-styrning/styrdokument-regelboken/forskning/forskningsdatapolicy-1.380915>
 * KTH -  <https://intra.kth.se/polopoly_fs/1.1037530.1608134393!/Riktlinje-om-hantering-av-forskningsdata.pdf> (Swedish), <https://intra.kth.se/polopoly_fs/1.1037531.1608134528!/Guidelines-on-managing-research-data.pdf> (English)
-* Uppsala University - 
+* Uppsala University -
 * Karolinska Institutet - <https://medarbetare.ki.se/riktlinjer-for-forskningsdokumentation-och-datahantering>, <https://medarbetare.ki.se/riktlinjer-for-forskning>
 * Linnaeus University - <https://lnu.se/globalassets/dokument---gemensamma/universitetsledningens-kansli/hanteringsanvisningar-for-forskningshandlingar.pdf>
 * Karlstads University - <http://intra.kau.se/dokument/upload/82F31D6802ef41E62BWs2F66E790/Policy%20for%20hantering%20av%20forskningsdata%20vid%20Karlstads%20universitet.pdf>

--- a/content/topic/research-data-office.md
+++ b/content/topic/research-data-office.md
@@ -1,16 +1,16 @@
 ---
-title: Research Data Office
+title: Research data office
 menu:
     bottom_about:
-        name: Research Data Office
-        identifier: rdo
+        name: Research data office
+        identifier: research-data-office
         weight: 10
 toc: True
 ---
 
 ## Research Data Office (RDO)
 
-Some of the universities have established an RDO or Data Access Unit (DAU), in order to help with data management questions. Also, the libraries can most often give advice or redirect to local instances. 
+Some of the universities have established an RDO or Data Access Unit (DAU), in order to help with data management questions. Also, the libraries can most often give advice or redirect to local instances.
 
 List of universities with RDOs, including links to local online resources and contact information:
 

--- a/content/topic/sensitive-data.md
+++ b/content/topic/sensitive-data.md
@@ -1,16 +1,26 @@
+---
+title: Sensitive data
+menu:
+    bottom_about:
+        name: Sensitive data
+        identifier: sensitive-personal
+        weight: 10
+toc: True
+---
+
 ## Sensitive personal data
 
 The following is a list of Ethical, Legal and Social Implications (ELSI) that should be considered when working with human data.
-The content on this page is based on a checklist that has been developed in the [Tryggve project](https://neic.no/tryggve/). It is intended be used as a tool to document these considerations, and is available as: 
-1. An MS Word file that can be downloaded from the [Tryggve project pages](https://neic.no/tryggve/links/). 
+The content on this page is based on a checklist that has been developed in the [Tryggve project](https://neic.no/tryggve/). It is intended be used as a tool to document these considerations, and is available as:
+1. An MS Word file that can be downloaded from the [Tryggve project pages](https://neic.no/tryggve/links/).
 2. In the [SciLifeLab Data Stewardship Wizard](https://dsw.scilifelab.se/) (SciLifeLab DSW)
   * Log in to the [SciLifeLab DSW](https://dsw.scilifelab.se/) using your university credentials
   * Select Projects in the left sidebar, and click the Create button
-  * Choose *ELSI Checklist Template* from the list of project templates 
+  * Choose *ELSI Checklist Template* from the list of project templates
 
 *Note that the checklist was created with cross-border collaborative projects in mind, but it should be useful for other research projects as well.*
 
-Before the collection of personal data has begun you should always consult with the [Data Protection Officer](data-protection-officer) of your organisation. 
+Before the collection of personal data has begun you should always consult with the [Data Protection Officer](data-protection-officer) of your organisation.
 
 ### Ethical reviews and informed consent ([more info](#ethical-reviews-and-informed-consents))
 
@@ -50,7 +60,7 @@ The purpose of these questions is to spell out what uses the subjects have conse
 #### GDPR
 
 ##### State the purpose of processing the personal data
-The GDPR stipulates that to process personal data the controller must do that with stated purposes, and not further process the data in a manner that is incompatible with those purposes ([Article 5 - Principles relating to processing of personal data](https://gdpr-info.eu/art-5-gdpr/)). 
+The GDPR stipulates that to process personal data the controller must do that with stated purposes, and not further process the data in a manner that is incompatible with those purposes ([Article 5 - Principles relating to processing of personal data](https://gdpr-info.eu/art-5-gdpr/)).
 
 ##### Who are the data controller of the personal data processed in the project?
 [Article 4](https://gdpr-info.eu/art-4-gdpr/) (7): _“‘**controller**’ means the natural or legal person, public authority, agency or other body which, alone or jointly with others, **determines the purposes** and means of the processing of personal data; […].”_ The Controller is typically the university employer of the PI, and the PI should act as a representative of her university employer and is responsible for ensuring that personal data is handled correctly in her projects. If the project involves more than one legal entity, and joint controllership is considered, make sure that all parties understand their obligations, and it is probably good to define the terms for this in an agreement between the parties.
@@ -74,10 +84,10 @@ Processing of certain categories of personal data is not allowed unless there ar
 Where a type of processing is likely to result in a high risk to the rights and freedoms of natural persons, the controller shall, prior to the processing, carry out an assessment of the impact of the envisaged processing operations on the protection of personal data, a so called _Data Protection Impact Assessment_ (DPIA) - [Article 35](https://gdpr-info.eu/art-35-gdpr/). To clarify when this is necessary, the Swedish Data Protection Authority (DPA) "Datainspektionen" has issued [guidance](https://www.datainspektionen.se/globalassets/dokument/beslut/list-regarding-data-protection-impact-assessments.pdf) of when an impact assessment is required. Large-scale processing of sensitive data such as genetic or other health related data is listed as requiring DPIAs. The French DPA has made a [PIA tool](https://www.cnil.fr/en/open-source-pia-software-helps-carry-out-data-protection-impact-assesment) (endorsed by several other DPAs) available that can help in performing these impact assessments. Please also consult your [Data Protection Officer](data-protection-officer) of your organisation.
 
 ##### What technical and procedural safeguards have been established for processing the data?
-To ensure that the personal data that you process in the project is protected at an appropriate level, you should apply technical and procedural safeguards to ensure that the rights of the data subjects are not violated. Examples of such measures include, but are not limited to, pseudonymisation end encryption of data, the use of computing and storage environments with heightened security, and clear and documented procedures for project members to follow. 
+To ensure that the personal data that you process in the project is protected at an appropriate level, you should apply technical and procedural safeguards to ensure that the rights of the data subjects are not violated. Examples of such measures include, but are not limited to, pseudonymisation end encryption of data, the use of computing and storage environments with heightened security, and clear and documented procedures for project members to follow.
 
 ##### What happens with the data after project completion?
-The GDPR states that the processing (including storing) of personal data should stop when the intended purpose of the processing is done. There are, however, exemptions to this e.g. when the processing is done for research purposes. Also, from a research ethics point of view, research data should be kept to make it possible for others to validate published research findings and reuse data for new discoveries. This is also governed by what the data subjects have been informed about regarding how you will treat the data after project completion. The recommendation is to deposit the sensitive data in the appropriate controlled access repositories if such are available, but this requires that the data subjects are informed and have agreed to this. 
+The GDPR states that the processing (including storing) of personal data should stop when the intended purpose of the processing is done. There are, however, exemptions to this e.g. when the processing is done for research purposes. Also, from a research ethics point of view, research data should be kept to make it possible for others to validate published research findings and reuse data for new discoveries. This is also governed by what the data subjects have been informed about regarding how you will treat the data after project completion. The recommendation is to deposit the sensitive data in the appropriate controlled access repositories if such are available, but this requires that the data subjects are informed and have agreed to this.
 
 #### Other considerations
 There might also exist other national legal or procedural considerations for cross-border research collaborations. Other laws might affect how and if data can or cannot be made available outside the country of origin. The operating procedures of government authorities or other organisations might create obstacles for sharing data across borders. To make sure that it is clear how original and derived data, as well as results, can be used by the parties after the project completion, consider establishing legal agreements that defines this. This can include e.g. reuse of data for other projects or intellectual property rights derived from the research project.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,12 +16,29 @@
         <div class="card-body">
           <h2 class="card-title no-anchor">Topic</h2>
           <p class="card-text">Click on either of the links below to get an overview of individual research data management topics. </p>
+            <div class ="row g-3 cont-links">
             {{ $topic := where .Site.RegularPages "Section" "topic" }}
-              {{ range $topic }}
-              <h6><a href="{{ .RelPermalink }}">{{ .Title }}</a></h6>
+            {{ range $topic }}
+              <div class="col-md-3 col-lg-4">
+                <div class="p-3 border rounded h-100">
+                  <div class="d-flex justify-content-between">
+                    <div>
+                      {{ if eq .Params.category "Human data"}}
+                      <i class="bi bi-person-fill"></i>
+                      {{else}}
+                      <i class="bi bi-info-square"></i>
+                      {{ end }}
+                      <b>
+                      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                      </b>
+                    </div>
+                  </div>
+                </div>
+              </div>
               {{ end }}
-        </div>
-      </div>
-    </div>
+            </div>
+          </div>
+          </div>
+          </div>
 </section>
 {{ end }}

--- a/layouts/shortcodes/display-topics.html
+++ b/layouts/shortcodes/display-topics.html
@@ -1,0 +1,21 @@
+<div class ="row g-3 cont-links">
+{{ $topic := where .Site.RegularPages "Section" "topic" }}
+{{ range $topic }}
+  <div class="col-md-3 col-lg-4">
+    <div class="p-3 border rounded h-100">
+      <div class="d-flex justify-content-between">
+        <div>
+          {{ if eq .Params.category "Human data"}}
+          <i class="bi bi-person-fill"></i>
+          {{else}}
+          <i class="bi bi-info-square"></i>
+          {{ end }}
+          <b>
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+          </b>
+        </div>
+      </div>
+    </div>
+  </div>
+  {{ end }}
+</div>


### PR DESCRIPTION
Changed the display of topics from the list format to boxes. This was done both on the front-page and on the topic page. Note that all topic pages are included in the display, including the pages concerning human data (Human data legal reference, Human data bioinformatician, Human data PI etc). These human data pages which will change from the work on issue Human data page #3. 

The icons in the boxes displayed before the topic name are only suggestion and we can change to other icons if desired (https://icons.getbootstrap.com). 