### PR TITLE
95 remove menus not used anymore

### DIFF
--- a/TEMPLATE_topic.md
+++ b/TEMPLATE_topic.md
@@ -1,10 +1,6 @@
 ---
 title: <!-- add title -->
-menu:
-    bottom_about:
-        name: <!-- short name -->
-        identifier: <!-- key word -->
-        weight: 10
+category: <!-- add category -->
 toc: True
 ---
 

--- a/content/data-life-cycle/analyse.md
+++ b/content/data-life-cycle/analyse.md
@@ -1,10 +1,5 @@
 ---
 title: Analysing phase
-menu:
-    bottom_cycle:
-        name: Analyse
-        identifier: analyse
-        weight: 40
 toc: True
 ---
 

--- a/content/data-life-cycle/collect.md
+++ b/content/data-life-cycle/collect.md
@@ -1,10 +1,5 @@
 ---
 title: Collecting phase
-menu:
-  bottom_cycle:
-        name: Collect
-        identifier: collect
-        weight: 20
 toc: True
 ---
 

--- a/content/data-life-cycle/plan.md
+++ b/content/data-life-cycle/plan.md
@@ -1,10 +1,5 @@
 ---
 title: Planning phase
-menu:
-    bottom_cycle:
-        name: Plan
-        identifier: plan
-        weight: 10
 toc: True
 ---
 

--- a/content/data-life-cycle/preserve.md
+++ b/content/data-life-cycle/preserve.md
@@ -1,10 +1,5 @@
 ---
 title: Preserving phase
-menu:
-    bottom_cycle:
-        name: Preserve
-        identifier: preserve
-        weight: 50
 toc: True
 ---
 

--- a/content/data-life-cycle/process.md
+++ b/content/data-life-cycle/process.md
@@ -1,10 +1,5 @@
 ---
 title: Processing phase
-menu:
-    bottom_cycle:
-        name: Processing
-        identifier: processing
-        weight: 30
 toc: True
 ---
 

--- a/content/data-life-cycle/reuse.md
+++ b/content/data-life-cycle/reuse.md
@@ -1,10 +1,5 @@
 ---
 title: Reusing phase
-menu:
-    bottom_cycle:
-        name: Reuse
-        identifier: reuse
-        weight: 70
 toc: True
 ---
 

--- a/content/data-life-cycle/share.md
+++ b/content/data-life-cycle/share.md
@@ -1,10 +1,5 @@
 ---
 title: Sharing phase
-menu:
-    bottom_cycle:
-        name: Share
-        identifier: share
-        weight: 60
 toc: True
 ---
 

--- a/content/topics/data-protection-officer.md
+++ b/content/topics/data-protection-officer.md
@@ -1,10 +1,5 @@
 ---
 title: Data Protection Officer
-menu:
-    bottom_topic:
-        name: Data Protection Officer
-        identifier: data-protection-officer
-        weight: 10
 toc: True
 ---
 

--- a/content/topics/data-transfer.md
+++ b/content/topics/data-transfer.md
@@ -1,10 +1,5 @@
 ---
 title: Data transfer
-menu:
-    bottom_topic:
-        name: Data transfer
-        identifier: data-transfer
-        weight: 10
 toc: True
 ---
 

--- a/content/topics/fair-principles.md
+++ b/content/topics/fair-principles.md
@@ -1,10 +1,5 @@
 ---
 title: FAIR principles
-menu:
-    bottom_topic:
-        name: FAIR principles
-        identifier: fair-principles
-        weight: 10
 toc: True
 ---
 

--- a/content/topics/general-processing-agreements.md
+++ b/content/topics/general-processing-agreements.md
@@ -1,10 +1,5 @@
 ---
 title: General processing agreements
-menu:
-    bottom_topic:
-        name: General processing agreements
-        identifier: data-transfer
-        weight: 10
 toc: True
 ---
 # General processing agreements for bioinformatics support and data storage

--- a/content/topics/human-data-PI.md
+++ b/content/topics/human-data-PI.md
@@ -1,11 +1,6 @@
 ---
 title: Human data PI
 category: Human data
-menu:
-    bottom_topic:
-        name: Human data PI
-        identifier: human-data-pi
-        weight: 10
 toc: True
 ---
 

--- a/content/topics/human-data-bioinformatician.md
+++ b/content/topics/human-data-bioinformatician.md
@@ -1,11 +1,6 @@
 ---
 title: Human data bioinformatician
 category: Human data
-menu:
-    bottom_topic:
-        name: Human data bioinformatician
-        identifier: human-data-bioinformatician
-        weight: 10
 toc: True
 ---
 # Working practices for NBIS bioinformaticians in support projects with human data

--- a/content/topics/human-data-legal-ref.md
+++ b/content/topics/human-data-legal-ref.md
@@ -1,11 +1,6 @@
 ---
 title: Human data legal reference
 category: Human data
-menu:
-    bottom_topic:
-        name: Human data legal reference
-        identifier: human-data-legal-reference
-        weight: 10
 toc: True
 ---
 

--- a/content/topics/metadata.md
+++ b/content/topics/metadata.md
@@ -1,10 +1,5 @@
 ---
 title: Metadata
-menu:
-    bottom_topic:
-        name: Metadata
-        identifier: metadata
-        weight: 10
 toc: True
 ---
 

--- a/content/topics/policies.md
+++ b/content/topics/policies.md
@@ -1,10 +1,5 @@
 ---
 title: University research data support
-menu:
-    bottom_topic:
-        name: University research data support
-        identifier: university-research-data-support
-        weight: 10
 toc: True
 ---
 

--- a/content/topics/sensitive-data.md
+++ b/content/topics/sensitive-data.md
@@ -1,10 +1,5 @@
 ---
 title: Sensitive data
-menu:
-    bottom_topic:
-        name: Sensitive data
-        identifier: sensitive-personal
-        weight: 10
 toc: True
 ---
 


### PR DESCRIPTION
Removed menus from RDLF and topics pages not used anymore. Also updated the topic template accordingly. 
This solves issue: Remove menus not used anymore #95