### PR TITLE
Change base container to Nginx unprivileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@
 FROM klakegg/hugo:0.101.0-onbuild AS build
 # On run, the image automatically copies the context folder to /src and performs a hugo build to /target
 
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:alpine
 COPY --from=build /target /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Perform a hugo build and copy the generated files into an nginx image
 
 # Check for recent versions/tags at https://hub.docker.com/r/klakegg/hugo/tags
-FROM klakegg/hugo:0.101.0-onbuild AS build
+FROM klakegg/hugo:0.104.3-ubuntu-onbuild AS build
 # On run, the image automatically copies the context folder to /src and performs a hugo build to /target
 
 FROM nginxinc/nginx-unprivileged:alpine


### PR DESCRIPTION
This pull request does two things:
* Bump Hugo to version 104.3
* Change the base of the nginx container to `nginxinc/nginx-unprivileged` to avoid running it as root.

This will require some changes in the Kubernetes deployment.