### PR TITLE
Add absolute_redirect off to avoid bad redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ FROM klakegg/hugo:0.104.3-ubuntu-onbuild AS build
 # On run, the image automatically copies the context folder to /src and performs a hugo build to /target
 
 FROM nginxinc/nginx-unprivileged:alpine
+RUN sed -i '3 a\    absolute_redirect off;' /etc/nginx/conf.d/default.conf
 COPY --from=build /target /usr/share/nginx/html


### PR DESCRIPTION
Add
```
    absolute_redirect off;
```
to avoid bad redirects to port 8080 when the container is behind a reverse proxy.