### PR TITLE
157 increase font size of page names in banners

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col-6 col-md">
-        <h6>Guidelines</h6>
+        <h4>Guidelines</h4>
         <ul class="list-unstyled text-small">
           {{ range .Site.Menus.bottom_guidelines }}
           <li class="mb-1"><a class="link-secondary text-decoration-none"
@@ -11,7 +11,7 @@
         </ul>
       </div>
       <div class="col-6 col-md">
-        <h6>About</h6>
+        <h4>About</h4>
         <ul class="list-unstyled text-small">
           {{ range .Site.Menus.bottom_about }}
           <li class="mb-1"><a class="link-secondary text-decoration-none"
@@ -20,7 +20,7 @@
         </ul>
       </div>
       <div class="col-6 col-md-4">
-        <h6>For more data-driven resources:</h6>
+        <h5>For more data-driven resources:</h5>
         <div class="p-0"><a href="https://data.scilifelab.se"><img src="/img/logos/Data_Platform_footer.svg"
               class="img-fluid"></a></div>
       </div>
@@ -31,7 +31,7 @@
         <div class="p-0"><a href="https://nbis.se"><img src="/img/logos/nbislogo-orange-txt.svg"></a></div>
       </div> -->
       <div class="col-6 col-md">
-        <h6>Site maintained by:</h6>
+        <h5>Site maintained by:</h5>
         <div class="p-0"><a href="https://scilifelab.se"><img src="/img/logos/scilifelab-logo.svg"
               class="img-fluid"></a></div>
         <div class="p-0 offset-md-1"><a href="https://nbis.se"><img src="/img/logos/nbislogo-orange-txt.svg"
@@ -55,7 +55,7 @@
             <a rel="license"
                  href="http://creativecommons.org/publicdomain/zero/1.0/">
                 <img src="https://licensebuttons.net/p/zero/1.0/80x15.png" style="border-style: none;" alt="CC0" />
-            </a>if not otherwise noted. 
+            </a>if not otherwise noted.
             </p>
           </span>
       </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,48 +1,9 @@
 {{ if not .IsHome }}
-{{/* Tags and authors sections need to behave as highlights section, hence the big exception below. */}}
-{{ if or (eq .Section "tags") (eq .Section "authors") }}
-{{ with .Site.GetPage "section" "highlights" }}
 <header class="header"
   style="background-image: url('{{ if .Params.header_image }}{{ .Params.header_image }}{{ else }}/img/illustrations/bubble_matrix.png{{ end }}');">
   <div class="container">
-    <h2>{{ .FirstSection.Title }}</h2>
+    <h1>{{ .FirstSection.Title }}</h1>
     {{ .FirstSection.Params.description }}
   </div>
 </header>
-{{ end }}
-{{ else }}
-<header class="header"
-  style="background-image: url('{{ if .Params.header_image }}{{ .Params.header_image }}{{ else }}/img/illustrations/bubble_matrix.png{{ end }}');">
-  <div class="container">
-    <h2>{{ .FirstSection.Title }}</h2>
-    {{ .FirstSection.Params.description }}
-  </div>
-</header>
-{{ end }}
-{{ if .Parent }}
-<nav class="breadcrumbs pt-1 bg-light" aria-label="breadcrumb">
-  <div class="container">
-    <ol class="breadcrumb">
-      {{ if .Parent.Parent }}
-      {{ if .Parent.Parent.Parent }}
-      {{ if .Parent.Parent.Parent.Parent }}
-      <li class="breadcrumb-item"><a
-          href="{{ .Parent.Parent.Parent.Parent.RelPermalink }}">{{ .Parent.Parent.Parent.Parent.Title }}</a></li>
-      {{ end }}
-      <li class="breadcrumb-item"><a
-          href="{{ .Parent.Parent.Parent.RelPermalink }}">{{ .Parent.Parent.Parent.Title }}</a></li>
-      {{ end }}
-      <li class="breadcrumb-item"><a href="{{ .Parent.Parent.RelPermalink }}">{{ .Parent.Parent.Title }}</a></li>
-      {{ end }}
-      {{ if or (eq .Section "tags") (eq .Section "authors") }}
-      <li class="breadcrumb-item"><a href="/highlights/">Data highlights</a>
-      <li class="breadcrumb-item">{{ .Parent.Title }}</li>
-      {{ else }}
-      <li class="breadcrumb-item"><a href="{{ .Parent.RelPermalink }}">{{ .Parent.Title }}</a></li>
-      {{ end }}
-      <li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
-    </ol>
-  </div>
-</nav>
-{{ end }}
 {{ end }}


### PR DESCRIPTION
This is from the issue: Increase font size of page names in banners #157

The headers on the banners 'about', 'contact', 'Research data life cycle', and 'topics' have gotten increased font. 

Also the headings 'Guidelines' and 'About' in the footer are increased. Same for the text 'For more data-driven resources:' and 'Site maintained by:'. 