### PR TITLE
158 document editorial structure

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -18,7 +18,9 @@ The guidelines adhere to the values of [Open Science](https://ec.europa.eu/info/
 
 The SciLifeLab RDM guidelines was built and is maintained by the [SciLifeLab Data Centre](https://scilifelab.se/data) and [NBIS](https://nbis.se). We welcome any questions on any element of the platform. Please get in touch with us by emailing [data-management@scilifelab.se](mailto:data-management@scilifelab.se) or by sending us a message using our [contact form](/contact/).
 
-The content of the website is moderated by the team behind the SciLifeLab RDM guidelines. However, contributions are welcome in each of the sections. For example, you can suggest [a new topic](/topics/) or an update to current [research data life cycle](/data-life-cycle) or [topic](/topics/) pages.
+The content of the website is moderated by an [editorial group](/about/contributors/) supported by the SciLifeLab RDM guidelines advisory group. However, contributions are welcome in each of the sections. For example, you can suggest [a new topic](/topics/) or an update to current [research data life cycle](/data-life-cycle) or [topic](/topics/) pages.
+
+<a href="/about/contributors/"><b>See all contributors <i class="bi bi-arrow-right-square-fill"></i></b></a>
 
 <a href="/contact/"><b>Contact form for enquiries and contributions <i class="bi bi-arrow-right-square-fill"></i></b></a>
 <br/><br/>
@@ -68,5 +70,5 @@ The content of the website is moderated by the team behind the SciLifeLab RDM gu
 </div>
 
 
-<a href="/about/contributors/"><b>See all contributors <i class="bi bi-arrow-right-square-fill"></i></b></a>
+
 <br/><br/>

--- a/content/about/contributors.md
+++ b/content/about/contributors.md
@@ -16,7 +16,8 @@ All internal contributors are listed below, divided by editorial and advisory gr
 ### Editorial group
 The editorial group is responsible for moderating the content of the RDM Guidelines site to keep it up to date and to drive further improvement.
 {{< contributors-editorial >}}
-Tasks:
+
+#### Tasks of the editorial group:
 * Manage the GitHub repository and review, prioritise and assign issues
 * Provide timely feedback to suggestions or questions submitted through the contact form
 * Review content and validate links to external resources on a regular basis

--- a/content/about/contributors.md
+++ b/content/about/contributors.md
@@ -17,13 +17,13 @@ All internal contributors are listed below, divided by editorial and advisory gr
 The editorial group is responsible for moderating the content of the RDM Guidelines site to keep it up to date and to drive further improvement.
 {{< contributors-editorial >}}
 Tasks:
-* Careful consideration and prioritisation of content updates.
-* Work together with contributors on how and where their specific contribution fits best.
-* Provide timely feedback for improving the quality of the content.
-* Provide templates and guidelines for contributions. 
-* Ensure that contributors are acknowledged.
+* Manage the GitHub repository and review, prioritise and assign issues
+* Provide timely feedback to suggestions or questions submitted through the contact form
+* Review content and validate links to external resources on a regular basis
+* Provide templates and guidelines for contributions 
+* Ensure that contributors are acknowledged
 
 
 ### Advisory group
-
+The advisory group is responsible for the long term development and sustainability of the RDM Guidelines site.
 {{< contributors-advisory >}}

--- a/content/about/contributors.md
+++ b/content/about/contributors.md
@@ -14,8 +14,16 @@ The SciLifeLab RDM guidelines was built and is maintained by the [SciLifeLab Dat
 All internal contributors are listed below, divided by editorial and advisory group.
 
 ### Editorial group
+The editorial group is responsible for moderating the content of the RDM Guidelines site to keep it up to date and to drive further improvement.
 {{< contributors-editorial >}}
+Tasks:
+* Careful consideration and prioritisation of content updates.
+* Work together with contributors on how and where their specific contribution fits best.
+* Provide timely feedback for improving the quality of the content.
+* Provide templates and guidelines for contributions. 
+* Ensure that contributors are acknowledged.
 
 
 ### Advisory group
+
 {{< contributors-advisory >}}


### PR DESCRIPTION
The contributors page has been updated with:

- A on sentence statement about responsibility for the editorial and the advisory group
- A list of tasks has for the editorial group on the 

The about page
- The link to all contributors has been moved to above the info about organisations
- The sentence on Content has been updated

Feedback on all text is appreciated and specifically, input on adding a "." or not to the sentences in the task list would be good.