### PR TITLE
Order and link text on homepage boxes changed

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -67,38 +67,39 @@
           <p class="card-text">{{ .Description }}</p>
           {{ end }}
           <div class="row">
-            <h4><b><a style="color:black" href={{ .Params.update_url }}>More information <i class="bi bi-arrow-right-circle-fill"></i></a></b></h4><br>
+            <h4><b><a style="color:black" href={{ .Params.update_url }}>More information on the event page <i class="bi bi-arrow-right-circle-fill"></i></a></b></h4><br>
         </div>
       </div>
     </div>
     {{ end }}
     {{ end }}
     <div class="card-body pb-4 px-0 pt-0">
-    <div class="card-body job rounded pt-1">
-      <h2><a style="color:black" href="/contact/">Calls & Jobs</a></h2>
-      <p class="card-text">Available positions and funding opportunities within data-driven life science can be found on the SciLifeLab Data Platform.
-        <br></p>
-      <div class="row">
-        <h4><b><a style="color:black" href="https://data.scilifelab.se/funding_calls/">Click here to go to calls <i
-                class="bi bi-arrow-right-circle-fill"></i></a></b></h4><br>
-      </div>
-      <div class="row">
-        <h4><b><a style="color:black" href="https://data.scilifelab.se/jobs/">Click here to go to jobs <i
-                class="bi bi-arrow-right-circle-fill"></i></a></b></h4><br>
-      </div>
-    </div>
-    </div>
-    <div class="card-body pb-4 px-0 pt-0">
     <div class="card-body training rounded pt-1">
       <h2><a style="color:black" href="/contact/">Events & Training</a></h2>
       <p class="card-text">Upcoming conferences, webinars, workshops, and training opportunities in Sweden related to data-driven life science can be found on the SciLifeLab Data Platform.
         <br></p>
       <div class="row">
-        <h4><b><a style="color:black" href="https://data.scilifelab.se/events/">Click here to go to Events & Training <i
+        <h4><b><a style="color:black" href="https://data.scilifelab.se/events/">Go to Events & Training on the Data Platform <i
                 class="bi bi-arrow-right-circle-fill"></i></a></b></h4><br>
       </div>
     </div>
     </div>
+    <div class="card-body pb-4 px-0 pt-0">
+    <div class="card-body job rounded pt-1">
+      <h2><a style="color:black" href="/contact/">Calls & Jobs</a></h2>
+      <p class="card-text">Available positions and funding opportunities within data-driven life science can be found on the SciLifeLab Data Platform.
+        <br></p>
+      <div class="row">
+        <h4><b><a style="color:black" href="https://data.scilifelab.se/funding_calls/">Go to calls on the Data Platform <i
+                class="bi bi-arrow-right-circle-fill"></i></a></b></h4><br>
+      </div>
+      <div class="row">
+        <h4><b><a style="color:black" href="https://data.scilifelab.se/jobs/">Go to jobs on the Data Platform <i
+                class="bi bi-arrow-right-circle-fill"></i></a></b></h4><br>
+      </div>
+    </div>
+    </div>
+
     </div>
   </div>
 </section>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -235,12 +235,12 @@ clear: both;
 
 /* Calls & Jobs block for the homepage */
 .job {
-    background-color: rgba(73, 31, 83, 0.25)!important;
+    background-color: rgba(76, 151, 159, 0.25)!important;
 }
 
 /* Events & Training block for the homepage */
 .training {
-    background-color: rgba(76, 151, 159, 0.25)!important;
+    background-color: rgba(73, 31, 83, 0.25)!important;
 }
 
 /*-----Cards-----*/


### PR DESCRIPTION
This will solve issue #182 

Changed the order of the boxes on the homepage. Switch place on jobs & events boxes.

Changed the 'link' text in the boxes to make it more clear that you will be taken to another site when following the link.