### PR TITLE
240 change of links to point to new cluster

### DIFF
--- a/content/privacy/_index.md
+++ b/content/privacy/_index.md
@@ -16,7 +16,7 @@ We want to inform you that whenever you visit our **Service**, we collect inform
 
 You can opt out of your Log Data being collected below:
 
-<iframe style="border: 0; height: 150px; width: 600px;" src="https://matomo.dckube.scilifelab.se/index.php?module=CoreAdminHome&action=optOut&language=en&fontFamily=Arial"></iframe>
+<iframe style="border: 0; height: 150px; width: 600px;" src="https://matomo.dc.scilifelab.se/index.php?module=CoreAdminHome&action=optOut&language=en&fontFamily=Arial"></iframe>
 
 ## Contact form
 

--- a/layouts/contact/list.html
+++ b/layouts/contact/list.html
@@ -3,8 +3,7 @@
 {{ .Content }}
 
 <div class="container">
-  <form action="https://forms.dckube.scilifelab.se/api/v1/form/7vxUAlrIJoY1lWDD/incoming" method="POST"
-    accept-charset="utf-8">
+  <form action="https://forms.dc.scilifelab.se/api/v1/form/7vxUAlrIJoY1lWDD/incoming" method="POST" accept-charset="utf-8">
     <div class="row mb-3 mt-2">
       <label for="name" class="col-sm-2 col-form-label fw-bold">Your name:</label>
       <div class="col-sm-10">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -79,7 +79,7 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function () {
-    var u = "//matomo.dckube.scilifelab.se/";
+    var u = "//matomo.dc.scilifelab.se/";
     _paq.push(['setTrackerUrl', u + 'matomo.php']);
     _paq.push(['setSiteId', '6']);
     var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];


### PR DESCRIPTION
Changed links for the form and for matomo so that they now link to the cluster (dc) instead of the old one (dckube). Links changed in three places after a search for 'dckube' in the code. 

