### PR TITLE
update RDM university links for KI

### DIFF
--- a/content/topics/university-rdm-resources.md
+++ b/content/topics/university-rdm-resources.md
@@ -29,8 +29,9 @@ Most often there are information resources at your university regarding research
     <tr>
       <td><a href="https://staff.ki.se/research-data-management">Karolinska Institutet</a></td>
       <td><a href = "mailto:rdo@ki.se">rdo@ki.se</a></td>
-      <td><a href="https://staff.ki.se/guidelines-for-research">Guidelines for research</a>
+      <td><a href="https://staff.ki.se/research-data-management">Research Data Management information</a>
       <br><a href="https://staff.ki.se/guidelines-for-research-documentation-and-data-management">Guidelines for research documentation and data management</a>
+       <br><a href="https://staff.ki.se/policy-for-open-access-to-research-data">Policy for open access to research data</a>
       </td>
     </tr>
     <tr>

--- a/content/topics/university-rdm-resources.md
+++ b/content/topics/university-rdm-resources.md
@@ -29,8 +29,7 @@ Most often there are information resources at your university regarding research
     <tr>
       <td><a href="https://staff.ki.se/research-data-management">Karolinska Institutet</a></td>
       <td><a href = "mailto:rdo@ki.se">rdo@ki.se</a></td>
-      <td><a href="https://staff.ki.se/research-data-management">Research Data Management information</a>
-      <br><a href="https://staff.ki.se/guidelines-for-research-documentation-and-data-management">Guidelines for research documentation and data management</a>
+      <td><a href="https://staff.ki.se/guidelines-for-research-documentation-and-data-management">Guidelines for research documentation and data management</a>
        <br><a href="https://staff.ki.se/policy-for-open-access-to-research-data">Policy for open access to research data</a>
       </td>
     </tr>


### PR DESCRIPTION
- Added a link to KI Policy for open access to research data https://staff.ki.se/policy-for-open-access-to-research-data (https://staff.ki.se/policy-for-open-access-to-research-data)

- Removed the link to KI Guidelines for research (https://staff.ki.se/guidelines-for-research) due to non RDM focus