### PR TITLE
Bump action methods version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,10 +34,10 @@ jobs:
       packages: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # only needed when publishing to Github (ghcr.io)
       - name: Log in to Github Container Repository
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           # will run as the user who triggered the action, using its token
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ matrix.images }}
           tags: |
@@ -54,7 +54,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - name: Build and Publish
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: ${{ matrix.dockerfile }}
           context: .

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,8 +4,6 @@
 name: Check broken links (htmltest)
 on:
   workflow_dispatch:
-    branches:
-      - main
   schedule:
     - cron: '15 8 1-7 * 3'
 
@@ -14,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "latest"
 
@@ -32,7 +30,7 @@ jobs:
           config: .github/htmltest-config.yml
 
       - name: Archive htmltest results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: htmltest-report
           path: tmp/.htmltest/htmltest.log

--- a/.github/workflows/trivy-branch.yaml
+++ b/.github/workflows/trivy-branch.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.9.2
@@ -34,7 +34,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: trivy-branch

--- a/.github/workflows/trivy-scheduled.yaml
+++ b/.github/workflows/trivy-scheduled.yaml
@@ -10,8 +10,6 @@ name: Trivy - scheduled scan
 
 on:
   workflow_dispatch:
-    branches:
-      - main
   schedule:
     - cron: '25 8,12 * * *'
 
@@ -24,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Ensure lowercase name
         run: echo REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
@@ -38,7 +36,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: trivy-cron


### PR DESCRIPTION
Github decides to use node v20 for actions from December 2024, so action methods using older version of node displays warnings about this.

In this PR the relevant methods are updated to use the latest versions. Already [done in pathogens portal](https://github.com/ScilifelabDataCentre/pathogens-portal/pull/1194), all looks good.