### PR TITLE
Fix branch name in URL

### DIFF
--- a/.github/workflows/pa11y_test.yaml
+++ b/.github/workflows/pa11y_test.yaml
@@ -32,5 +32,5 @@ jobs:
               run: |
                 pa11y-ci \
                   --config ${GITHUB_WORKSPACE}/.github/pa11y.config \
-                  --sitemap https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/develop/.github/sitemap.xml \
+                  --sitemap https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/.github/sitemap.xml \
                   --sitemap-exclude 'https://data-guidelines.scilifelab.se/files'


### PR DESCRIPTION
In the workflow file, I have put `develop` instead of `main`. Since the `develop` branch doesn't exists the URL is invalid and `pa11y` will not have any sitemap to check the URLs.

That is why even though the [workflow](https://github.com/ScilifelabDataCentre/RDM-guidelines/actions/runs/11476237942) ran successfully no URLs were checked.
>0/0 URLs passed