### PR TITLE
Update info about FEGA Sweden

### DIFF
--- a/content/data-life-cycle/share.md
+++ b/content/data-life-cycle/share.md
@@ -112,7 +112,7 @@ Click on the buttons below for specific information regarding suitable repositor
 <div class="collapse" id="collapseExample4">
   <div class="card card-body">
   <span>
-  <a href="https://fega.nbis.se/">FEGA Sweden</a> This is a repository for storing and sharing personally identifiable genetic and phenotypic data in Sweden in a way that meets the requirements of the General Data Protection Regulation (GDPR). It is part of the <a href="https://ega-archive.org/about/projects-and-funders/federated-ega/">Federated European Genome-phenome Archive</a>, which is a network consisting of several national nodes and the European Genome-phenome Archive (EGA). FEGA Sweden is currently transitioning into operational mode and researchers may express their interest in depositing data to the repository by filling in <a href="https://fega.nbis.se/submission/submission-request.html">a web form</a>.
+  <a href="https://fega.nbis.se/">FEGA Sweden</a> This is a repository for storing and sharing personally identifiable genetic and phenotypic data in Sweden in a way that meets the requirements of the General Data Protection Regulation (GDPR). It is part of the <a href="https://ega-archive.org/about/projects-and-funders/federated-ega/">Federated European Genome-phenome Archive</a>, which is a network consisting of several national nodes and the European Genome-phenome Archive (EGA). Researchers can create a submission request by filling in a form on the website</a>.
   </span>
   </div>
   <br>

--- a/content/topics/sharing-human-data.md
+++ b/content/topics/sharing-human-data.md
@@ -33,7 +33,7 @@ Here are some repositories for sharing and archiving data under controlled acces
 [European Genome-phenome Archive](https://ega-archive.org) is a service for sharing personally identifiable genetic and phenotypic data resulting from biomedical research projects. The repository is hosted by the European Bioinformatics Institute (EMBL-EBI) and the Centre for Genomic Regulation (CRG). Any data submitted to the repository is subject to controlled access, which means that access to the data only will be granted after a formal application procedure.
 
 ### FEGA Sweden
-[FEGA Sweden](https://fega.nbis.se/) is a repository for storing and sharing personally identifiable genetic and phenotypic data in Sweden in a way that meets the requirements of the General Data Protection Regulation (GDPR). It is part of the [Federated European Genome-phenome Archive](https://ega-archive.org/about/projects-and-funders/federated-ega/) (FEGA), which is a network consisting of several national nodes and the European Genome-phenome Archive (EGA). FEGA Sweden is currently transitioning into operational mode and researchers may express their interest in depositing data to the repository by filling in [a web form](https://fega.nbis.se/submission/submission-request.html). If you would like more information or have any questions regarding FEGA Sweden, please feel free to contact the FEGA Sweden Helpdesk at [ega-se@nbis.se](mailto:ega-se@nbis.se) 
+[FEGA Sweden](https://fega.nbis.se/) is a repository for storing and sharing personally identifiable genetic and phenotypic data in Sweden in a way that meets the requirements of the General Data Protection Regulation (GDPR). It is part of the [Federated European Genome-phenome Archive](https://ega-archive.org/about/projects-and-funders/federated-ega/) (FEGA), which is a network consisting of several national nodes and the European Genome-phenome Archive (EGA). Researchers can create a submission request by filling in a form on the website. If you would like more information or have any questions regarding FEGA Sweden, please feel free to contact the FEGA Sweden Helpdesk at [ega-se@nbis.se](mailto:ega-se@nbis.se) 
 
 
 ### Analytic Imaging Diagnostics Arena (AIDA) Data Hub
@@ -63,16 +63,12 @@ If you are a researcher at a Swedish academic institution working in the life sc
 
 ### Submission support for FEGA Sweden
 
-FEGA Sweden is not yet in production, but you can get help with preparations for a future submission to the repository. The FEGA Sweden Helpdesk is part of the larger data management support team at SciLifeLab. Visit the [FEGA Sweden website](https://fega.nbis.se) to learn more about how you can prepare a submission and how to get in contact with the FEGA Sweden Helpdesk.
+The FEGA Sweden Helpdesk can help you submitting data to the repository. The helpdesk is part of the larger data management support team at SciLifeLab. Visit the [FEGA Sweden website](https://fega.nbis.se) to learn more about how you can prepare a submission and how to get in contact with the FEGA Sweden Helpdesk.
 
 
-### Data access management support
+### Data access management support for Bianca
 
-If your data is located on the Bianca server at UPPMAX (or in the future deposited in FEGA Sweden), we can help with handling data access requests.
-
-<div class="alert alert-warning" role="alert">
-Until FEGA Sweden is ready for both storing and sharing data, we can only support data sharing with principal investigators that are eligible for setting up a project on Bianca server at UPPMAX.
-</div>
+If your data is located on the Bianca server at UPPMAX, we can help with handling data access requests.
 
 To let us handle access requests to your data, you need to take the following steps:
 
@@ -82,7 +78,7 @@ To let us handle access requests to your data, you need to take the following st
 4. In your manuscript add a section on Data Availability and make sure it includes information on where to go for requesting access to the data. You could for example write the following in your manuscript:
 > The data is deposited on a secure Swedish server and has been assigned a DOI (XXX). Data access requests may be submitted to the Science for Life Laboratory Data Centre through the DOI link.
 5. When a user applies for access to `datacentre@scilifelab.se`, the application will be vetted and you will be contacted by us. Then you can make a decision on access approved or denied. Ideally, you can (should) delegate this decision to an independent Data Access Committee (DAC).
-6. When a user has been approved for access, SciLifeLab Data Centre will document the processing and arrange for the physical file access. Until FEGA Sweden is up and running, the physical file access will be that you, as a PI, copies the dataset from your Bianca project space, to the specified project space of the approved applicant. Because of NAISS user policy, only PIs at a Swedish academic institution can have a project at Bianca. So to share data with a collaborator outside Sweden, the PI in Sweden needs to have applied for a project at Bianca. Please see the [Bianca user guide](https://docs.uppmax.uu.se/cluster_guides/bianca/) for information on how to do this.
+6. When a user has been approved for access, SciLifeLab Data Centre will document the processing and arrange for the physical file access. The physical file access will be that you, as a PI, copies the dataset from your Bianca project space, to the specified project space of the approved applicant. Because of NAISS user policy, only PIs at a Swedish academic institution can have a project at Bianca. So to share data with a collaborator outside Sweden, the PI in Sweden needs to have applied for a project at Bianca. Please see the [Bianca user guide](https://docs.uppmax.uu.se/cluster_guides/bianca/) for information on how to do this.
 7. SciLifeLab Data Centre will keep track of current and expired approvals.
 
 If you need any help connected to data submission, please [contact us](../../contact/)!


### PR DESCRIPTION
This PR contains the following changes:

- Removed info saying that FEGA Sweden is not operational
- Updated section about data access management support
  - "for Bianca" appended to the heading
  - Removed any information about FEGA Sweden from the instructions