### PR TITLE
Remove blue background on click

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -47,11 +47,22 @@ a {
   text-decoration: none;
 }
 
-a:hover{
+a:hover {
   text-decoration: underline;
   text-underline-offset: 3.2px;
 }
 
+.dropdown-item.hover, .dropdown-item:hover {
+  color: #fff;
+  text-decoration: none;
+  background-color: rgba(229, 229, 229, 0.5);
+}
+
+.dropdown-item.active, .dropdown-item:active {
+  color: #fff;
+  text-decoration: none;
+  background-color: rgba(229, 229, 229, 1);
+}
 
 .toc-style a {
   color: #045c64;


### PR DESCRIPTION
The dropdown-menu used for grouping human data topics had an annoying feature, background of an item becoming blue when clicked. This is now replaced with a grey color.