### PR TITLE
Fix hyperlink contrast issue

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -187,11 +187,13 @@ h4 {
 
 a {
   text-decoration: none;
+  color: blue;
 }
 
 a:hover {
   text-decoration: underline;
   text-underline-offset: 3.2px;
+  color: darkblue;
 }
 
 .dropdown-item.hover, .dropdown-item:active {


### PR DESCRIPTION
With this update, the contrast ratio is 6.82:1 (and 12.14:1 on hover), which is well above requirements