### PR TITLE
Update search tag to match title: National guidelines for open science

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -876,7 +876,7 @@
             "short_title": "National guidelines for open science",
             "target": ["guidance"],
             "type": ["Material"],
-            "search_tags": ["National Library of Sweden","Open Science", "National national guidelines for open science", "policy"],
+            "search_tags": ["National Library of Sweden","Open Science", "National guidelines for open science", "policy"],
             "phase": ["Share", "Reuse"],
             "topic": ["Sharing code and workflows", "University RDM resources"],
             "level": ["Basic"],


### PR DESCRIPTION
There was a typo in the `data/resources.json` file. The search tag "National guidelines for open science" contained the word "national" twice