### PR TITLE
705 Remove color styling in header.html

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 </div>{{ if .IsHome }}
-  <header class="header" style="background-image: url('/img/illustrations/circle_zoomed.png'); color: white; background-color: #42786E">
+  <header class="header" style="background-image: url('/img/illustrations/circle_zoomed.png')">
     <div class="container">
       <div class="py-2 my-1">
         {{ .Content }}
@@ -9,7 +9,7 @@
 {{ else }}
 {{ with .Site.GetPage "section" }}
 <header class="header"
-  style="background-image: url('{{ if .Params.header_image }}{{ .Params.header_image }}{{ else }}/img/illustrations/bubble_matrix.png{{ end }}'); color:white; background-color: #42786E">
+  style="background-image: url('{{ if .Params.header_image }}{{ .Params.header_image }}{{ else }}/img/illustrations/bubble_matrix.png{{ end }}')">
   <div class="container">
     <h1>{{ .FirstSection.Title }}</h1>
     {{ .FirstSection.Params.description }}
@@ -17,7 +17,7 @@
 </header>
 {{ else }}
 <header class="header"
-  style="background-image: url('{{ if .Params.header_image }}{{ .Params.header_image }}{{ else }}/img/illustrations/bubble_matrix.png{{ end }}'); color:white; background-color: #42786E">
+  style="background-image: url('{{ if .Params.header_image }}{{ .Params.header_image }}{{ else }}/img/illustrations/bubble_matrix.png{{ end }}')">
   <div class="container">
     <h1>{{ .FirstSection.Title }}</h1>
     {{ .FirstSection.Params.description }}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -316,7 +316,7 @@ h1 a:hover {
   background-repeat: no-repeat;
   background-size: cover;
   padding: 1.5rem 0;
-  color: var(--light_grey);
+  color: white;
   box-shadow: rgba(17, 17, 26, 0.1) 0px 4px 16px,
     rgba(17, 17, 26, 0.05) 0px 8px 32px;
 }


### PR DESCRIPTION
### Summary
<!-- Briefly describe WHAT and WHY of this PR -->
The partial header.html had color styling, and we prefer to have as much as possible of the styling in the styles.css instead.
 
### Changes Made
<!-- One-liners or bullet points -->
- Removed both `color` and `background-color` from the three types of headers we have
- In styles.css `color` was changed from light-grey to white

### Notes for Reviewers
<!-- Tips, edge cases, or test instructions -->
* For `color`, I don't see that the change to white has any unwanted side effects, but be aware.
* For `background-color` removing it had no effect, but if found, we can use `var(--teal075)` instead of the original color (i.e. we don't have to create a new variable for such a similar color).

### Checklist
- [x] PR title is a clear and short description
- [x] Related Github issue is linked
- [ ] Assignee is selected
- [x] Automated checks pass
