### PR TITLE
Add chrome executablePath

### DIFF
--- a/.github/pa11y.config
+++ b/.github/pa11y.config
@@ -2,8 +2,9 @@
     "defaults": {
         "hideElements": "div.g-recaptcha, iframe[style*='display: none']",
         "chromeLaunchConfig": {
-            "ignoreHTTPSErrors": true,
-            "args": ["--disable-dev-shm-usage", "--no-sandbox"]
+            "args": ["--disable-dev-shm-usage", "--no-sandbox"],
+            "executablePath": "/usr/bin/google-chrome",
+            "ignoreHTTPSErrors": true
         }
     }
 }


### PR DESCRIPTION
This PR fixes `pa11y-ci` action that fails with node `v24.16`. Something changed between `v24.15` and `v24.16`, thus pa11y-ci couldn't find the browser. Specifying the executionPath in the config fixes the issue.